### PR TITLE
Replace materialdesignicons.com with pictogrammers.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Search [materialdesignicons.com](https://materialdesignicons.com/) icons with [Flow Launcher](https://github.com/Flow-Launcher/Flow.Launcher)
+Search [pictogrammers.com/library/mdi/](https://pictogrammers.com/library/mdi/) icons with [Flow Launcher](https://github.com/Flow-Launcher/Flow.Launcher)
 
 ## Install
 
@@ -17,7 +17,7 @@ Simply type the keywords: `mdi` to search!
 
 Selected results are added to your clipboard.
 
-`SHIFT`+`ENTER` allows you to open the icon on https://materialdesignicons.com/
+`SHIFT`+`ENTER` allows you to open the icon on https://pictogrammers.com/library/mdi/
 
 ## Screenshots
 ![image](https://user-images.githubusercontent.com/535299/147867481-92e3158a-f87d-4a34-8cd3-b68e3d8a825b.png)

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "ID": "8g5cdc9a78ef4a7e667e138f1fc04015",
   "ActionKeyword": "mdi",
   "Name": "Search-MDI",
-  "Description": "Search materialdesignicons.com",
+  "Description": "Search pictogrammers.com/library/mdi/",
   "Author": "Garulf",
   "Version": "3.0.3",
   "Language": "python",

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -13,7 +13,7 @@ from flox.clipboard import Clipboard
 META_FILE = "meta.json"
 META_PATH = Path(Path.cwd(), 'plugin', META_FILE)
 MAX_RESULTS = 100
-MDI_URL = "https://materialdesignicons.com/icon/"
+MDI_URL = "https://pictogrammers.com/library/mdi/icon/"
 
 
 class MDI(Flox, Clipboard):


### PR DESCRIPTION
Some time ago, https://materialdesignicons.com started redirecting to https://pictogrammers.com/library/mdi/ which is causing the URL copying feature to stop working. This changes the copy URL to use the new https://pictogrammers.com/library/mdi/ URL.

This doesn't update the actual icon font or meta.json and some icons might have been deprecated in the time since the last update.